### PR TITLE
Fix typo in text of finishing dialog

### DIFF
--- a/netflix_prep_install.sh
+++ b/netflix_prep_install.sh
@@ -32,7 +32,7 @@ mv master.zip  plugin.video.netflix.zip
 
 sudo systemctl stop mediacenter
 sleep 5
-dialog --title "Installation finnished!" --msgbox "\nThank you for using my installer\nNow go to addon-browsser and choose install from zip\nNavigate to homefolder/addons and install netflix plugin." 11 70
+dialog --title "Installation finished!" --msgbox "\nThank you for using my installer\nNow go to addon-browser and choose install from zip\nNavigate to homefolder/addons and install Netflix plugin." 11 70
 if [ -f "/home/osmc/netflix_prep_install.sh" ]; then
 	rm /home/osmc/netflix_prep_install.sh
 fi	


### PR DESCRIPTION
Small changes applied on the text of last dialog of installer to fix small typos without modifying any  behavior of the script.