### PR TITLE
Update netflix_prep_install.sh

### DIFF
--- a/netflix_prep_install.sh
+++ b/netflix_prep_install.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 #Set UTF-8; e.g. "en_US.UTF-8" or "de_DE.UTF-8":
+export LANGUAGE="en_US.UTF-8"
+export LANG="en_US.UTF-8"
 export LC_ALL="en_US.UTF-8"
+sudo locale-gen en_US.UTF-8
 
 #Tell ncurses to use line characters that work with UTF-8.
 export NCURSES_NO_UTF8_ACS=1
@@ -8,7 +11,7 @@ export NCURSES_NO_UTF8_ACS=1
 cd /home/osmc
 sudo apt-get update 2>&1 | dialog --title "Updating package database and installing needed .deb packages..." --infobox "\nPlease wait...\n" 11 70 
 if [ ! -d /usr/share/doc/python-crypto ]; then
-	sudo apt-get install -q python-crypto
+	sudo apt-get install -q -y python-crypto
 fi
 sudo apt-get install -q -y build-essential python-pip libnss3 libnspr4
 


### PR DESCRIPTION
Correct locales setup because of shell error and perl warning:

```
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  python-crypto-dbg python-crypto-doc
The following NEW packages will be installed:
  python-crypto
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 255 kB of archives.
After this operation, 1335 kB of additional disk space will be used.
Get:1 http://ftp.debian.org/debian stretch/main armhf python-crypto armhf 2.6.1-7 [255 kB]
Fetched 255 kB in 0s (729 kB/s)
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = "en_US.UTF-8",
        LANG = "C"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Selecting previously unselected package python-crypto.
(Reading database ... 25969 files and directories currently installed.)
Preparing to unpack .../python-crypto_2.6.1-7_armhf.deb ...
Unpacking python-crypto (2.6.1-7) ...
Setting up python-crypto (2.6.1-7) ...
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)

```
Adding force "yes" for installation of "python-crypto" package in if condition